### PR TITLE
feat: Trigger filter priority

### DIFF
--- a/.github/workflows/filter_priority.yml
+++ b/.github/workflows/filter_priority.yml
@@ -18,17 +18,7 @@ name: Filter Priority
 # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore
 # But it is unclear how `paths` plays into it, is it: `paths || (tags && branches)` or `paths && tags && branches` if all are defined.
 
-# Test Scenario 1: !tags && branch && paths =
-on:
-  push:
-    tags:
-      - filter-priority
-    branches:
-      - filter-priority
-    paths:
-      - ".github/workflows/filter_priority.yml"
-
-# Test Scenario 2: tags && branch && !paths =
+# Test Scenario 1: !tags && branch && paths = true
 # on:
 #   push:
 #     tags:
@@ -36,9 +26,19 @@ on:
 #     branches:
 #       - filter-priority
 #     paths:
-#       - "README.md"
+#       - ".github/workflows/filter_priority.yml"
 
-# Test Scenario 2: !tags && branch && !paths =
+# Test Scenario 2: tags && branch && !paths =
+on:
+  push:
+    tags:
+      - filter-priority
+    branches:
+      - filter-priority
+    paths:
+      - "README.md"
+
+# Test Scenario 3: !tags && branch && !paths =
 # on:
 #   push:
 #     tags:
@@ -48,7 +48,7 @@ on:
 #     paths:
 #       - "README.md"
 
-# Test Scenario 3: !tags && !branch && paths =
+# Test Scenario 4: !tags && !branch && paths =
 # on:
 #   push:
 #     tags:

--- a/.github/workflows/filter_priority.yml
+++ b/.github/workflows/filter_priority.yml
@@ -25,8 +25,8 @@ on:
     branches:
       - nothing
     paths:
-      - "README.md"
-      # - ".github/workflows/filter_priority.yml"
+      # - "README.md"
+      - ".github/workflows/filter_priority.yml"
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/filter_priority.yml
+++ b/.github/workflows/filter_priority.yml
@@ -35,4 +35,4 @@ jobs:
   filter-priority:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "Hello World!"
+      - run: echo "${{ toJSON(github.event) }}" 

--- a/.github/workflows/filter_priority.yml
+++ b/.github/workflows/filter_priority.yml
@@ -40,15 +40,25 @@ name: Filter Priority
 #     paths:
 #       - "README.md"
 
-# Test Scenario 3: !tags && !branch && paths =
+# Test Scenario 3: !tags && !branch && paths = false
+# on:
+#   push:
+#     tags:
+#       - filter-priority
+#     branches:
+#       - nothing
+#     paths:
+#       - ".github/workflows/filter_priority.yml"
+
+# Test Scenario 4: (!)tags && branch = ?
+# on commit: !tags && branch =
+# on tag: tags && branch =
 on:
   push:
     tags:
       - filter-priority
     branches:
-      - nothing
-    paths:
-      - ".github/workflows/filter_priority.yml"
+      - filter-priority
 
 permissions: {}
 

--- a/.github/workflows/filter_priority.yml
+++ b/.github/workflows/filter_priority.yml
@@ -25,7 +25,8 @@ on:
     branches:
       - nothing
     paths:
-      - ".github/workflows/filter_priority.yml"
+      - "README.md"
+      # - ".github/workflows/filter_priority.yml"
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/filter_priority.yml
+++ b/.github/workflows/filter_priority.yml
@@ -16,7 +16,7 @@ name: Filter Priority
 
 # The behavior of the `tag` and `branch` filters is clearly described in the docs:
 # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore
-# But it is unclear how `paths` plays into it, is it: `paths || (tags && branches)` or `paths && tags && branches` if all are defined.
+# But it is unclear how `paths` plays into it, is it: `paths || (tags && branches)` or `paths && tags && branches` if all are defined?
 
 # Test Scenario 1: !tags && branch && paths = true
 # on:
@@ -28,7 +28,19 @@ name: Filter Priority
 #     paths:
 #       - ".github/workflows/filter_priority.yml"
 
-# Test Scenario 2: tags && branch && !paths =
+# Test Scenario 2: tags && branch && !paths = ?
+# on commit: tags && branch && !paths = false
+# on tag: tags && branch && !paths = true
+# on:
+#   push:
+#     tags:
+#       - filter-priority
+#     branches:
+#       - filter-priority
+#     paths:
+#       - "README.md"
+
+# Test Scenario 3: !tags && branch && !paths =
 on:
   push:
     tags:
@@ -37,16 +49,6 @@ on:
       - filter-priority
     paths:
       - "README.md"
-
-# Test Scenario 3: !tags && branch && !paths =
-# on:
-#   push:
-#     tags:
-#       - filter-priority
-#     branches:
-#       - nothing
-#     paths:
-#       - "README.md"
 
 # Test Scenario 4: !tags && !branch && paths =
 # on:

--- a/.github/workflows/filter_priority.yml
+++ b/.github/workflows/filter_priority.yml
@@ -28,7 +28,7 @@ name: Filter Priority
 #     paths:
 #       - ".github/workflows/filter_priority.yml"
 
-# Test Scenario 2: tags && branch && !paths = ?
+# Test Scenario 2: (!)tags && branch && !paths = ?
 # on commit: tags && branch && !paths = false
 # on tag: tags && branch && !paths = true
 # on:
@@ -40,25 +40,15 @@ name: Filter Priority
 #     paths:
 #       - "README.md"
 
-# Test Scenario 3: !tags && branch && !paths =
+# Test Scenario 3: !tags && !branch && paths =
 on:
   push:
     tags:
       - filter-priority
     branches:
-      - filter-priority
+      - nothing
     paths:
-      - "README.md"
-
-# Test Scenario 4: !tags && !branch && paths =
-# on:
-#   push:
-#     tags:
-#       - filter-priority
-#     branches:
-#       - nothing
-#     paths:
-#       - ".github/workflows/filter_priority.yml"
+      - ".github/workflows/filter_priority.yml"
 
 permissions: {}
 

--- a/.github/workflows/filter_priority.yml
+++ b/.github/workflows/filter_priority.yml
@@ -1,0 +1,35 @@
+# Copyright Jacob Wujciak-Jens 
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Filter Priority
+
+# The behavior of the `tag` and `branch` filters is clearly described in the docs:
+# https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore
+# But it is unclear how `paths` plays into it, is it: `paths || (tags && branches)` or `paths && tags && branches` if all are defined.
+
+on:
+  push:
+    branches:
+      - filter-priority
+    paths:
+      - "README.md"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  filter-priority:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Hello World!"

--- a/.github/workflows/filter_priority.yml
+++ b/.github/workflows/filter_priority.yml
@@ -29,7 +29,7 @@ name: Filter Priority
 #       - ".github/workflows/filter_priority.yml"
 
 # Test Scenario 2: (!)tags && branch && !paths = ?
-# on commit: tags && branch && !paths = false
+# on commit: !tags && branch && !paths = false
 # on tag: tags && branch && !paths = true
 # on:
 #   push:
@@ -51,14 +51,27 @@ name: Filter Priority
 #       - ".github/workflows/filter_priority.yml"
 
 # Test Scenario 4: (!)tags && branch = ?
-# on commit: !tags && branch =
-# on tag: tags && branch =
+# on commit: !tags && branch = true
+# on tag: tags && branch = true
+# This should not run on commit according to the docs but does?
+# > If you define both branches/branches-ignore and paths/paths-ignore,
+# > the workflow will only run when both filters are satisfied.
+# on:
+#   push:
+#     tags:
+#       - filter-priority
+#     branches:
+#       - filter-priority
+
+# Test Scenario 5: (!)tags && !branch = ?
+# on commit: !tags && !branch =
+# on tag: tags && !branch =
 on:
   push:
     tags:
       - filter-priority
     branches:
-      - filter-priority
+      - nothing
 
 permissions: {}
 

--- a/.github/workflows/filter_priority.yml
+++ b/.github/workflows/filter_priority.yml
@@ -23,7 +23,7 @@ on:
     branches:
       - filter-priority
     paths:
-      - "README.md"
+      - ".github/workflows/filter_priority.yml"
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/filter_priority.yml
+++ b/.github/workflows/filter_priority.yml
@@ -1,4 +1,4 @@
-# Copyright Jacob Wujciak-Jens 
+# Copyright Jacob Wujciak-Jens
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,16 +18,45 @@ name: Filter Priority
 # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore
 # But it is unclear how `paths` plays into it, is it: `paths || (tags && branches)` or `paths && tags && branches` if all are defined.
 
+# Test Scenario 1: !tags && branch && paths =
 on:
   push:
     tags:
       - filter-priority
     branches:
-      - nothing
+      - filter-priority
     paths:
-      # - "README.md"
       - ".github/workflows/filter_priority.yml"
-  workflow_dispatch:
+
+# Test Scenario 2: tags && branch && !paths =
+# on:
+#   push:
+#     tags:
+#       - filter-priority
+#     branches:
+#       - filter-priority
+#     paths:
+#       - "README.md"
+
+# Test Scenario 2: !tags && branch && !paths =
+# on:
+#   push:
+#     tags:
+#       - filter-priority
+#     branches:
+#       - nothing
+#     paths:
+#       - "README.md"
+
+# Test Scenario 3: !tags && !branch && paths =
+# on:
+#   push:
+#     tags:
+#       - filter-priority
+#     branches:
+#       - nothing
+#     paths:
+#       - ".github/workflows/filter_priority.yml"
 
 permissions: {}
 
@@ -35,4 +64,4 @@ jobs:
   filter-priority:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "${{ toJSON(github.event) }}" 
+      - run: echo "${{ toJSON(github.event) }}"

--- a/.github/workflows/filter_priority.yml
+++ b/.github/workflows/filter_priority.yml
@@ -14,9 +14,10 @@
 
 name: Filter Priority
 
-# The behavior of the `tag` and `branch` filters is clearly described in the docs:
+# The docs for the interplay of the `tags`, `branches` and `paths` filters is bit unclear 
 # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore
-# But it is unclear how `paths` plays into it, is it: `paths || (tags && branches)` or `paths && tags && branches` if all are defined?
+# With the below test cases it becomes clear that the workflow runs if this is true: tags || (branches && paths) 
+# If `branches` or `tags` are not defined they are true.
 
 # Test Scenario 1: !tags && branch && paths = true
 # on:
@@ -53,9 +54,6 @@ name: Filter Priority
 # Test Scenario 4: (!)tags && branch = ?
 # on commit: !tags && branch = true
 # on tag: tags && branch = true
-# This should not run on commit according to the docs but does?
-# > If you define both branches/branches-ignore and paths/paths-ignore,
-# > the workflow will only run when both filters are satisfied.
 # on:
 #   push:
 #     tags:
@@ -64,14 +62,15 @@ name: Filter Priority
 #       - filter-priority
 
 # Test Scenario 5: (!)tags && !branch = ?
-# on commit: !tags && !branch =
-# on tag: tags && !branch =
+# on commit: !tags && !branch = false
+# on tag: tags && !branch = true
 on:
   push:
     tags:
       - filter-priority
     branches:
       - nothing
+
 
 permissions: {}
 

--- a/.github/workflows/filter_priority.yml
+++ b/.github/workflows/filter_priority.yml
@@ -20,6 +20,8 @@ name: Filter Priority
 
 on:
   push:
+    tags:
+      - filter-priority
     branches:
       - filter-priority
     paths:

--- a/.github/workflows/filter_priority.yml
+++ b/.github/workflows/filter_priority.yml
@@ -23,7 +23,7 @@ on:
     tags:
       - filter-priority
     branches:
-      - filter-priority
+      - nothing
     paths:
       - ".github/workflows/filter_priority.yml"
   workflow_dispatch:


### PR DESCRIPTION
I wanted to be sure I understand the exact interplay between the `tags`, `branches` and `paths` filters. So I created a workflow to explore it in a structured way.

The answer is that the workflow runs if: `tags || (branches && paths)` 
If `branches` or `tags` are not defined they are true.
