### PR TITLE
feat: add caching for Docker between jobs without a registry

### DIFF
--- a/.github/workflows/docker-caching.yml
+++ b/.github/workflows/docker-caching.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Build Stage 2
         run: |
-          docker build --target stage1
+          docker build --target stage1 .
 
   stage2:
     needs: base-image
@@ -126,4 +126,4 @@ jobs:
 
       - name: Build Stage 2
         run: |
-          docker build --target stage2
+          docker build --target stage2 .

--- a/.github/workflows/docker-caching.yml
+++ b/.github/workflows/docker-caching.yml
@@ -79,7 +79,7 @@ jobs:
           context: .
           target: base
           tags: base:latest
-          cache-to: type=local,dest=/tmp/docker_cache
+          cache-to: type=local,dest=/tmp/docker_cache,compression=zstd
           push: false
 
       - name: Upload Docker Cache

--- a/.github/workflows/docker-caching.yml
+++ b/.github/workflows/docker-caching.yml
@@ -21,7 +21,7 @@
 # by multiple other images that all have a long build time and thus benefit
 # from parallelization.
 #
-# So let's find a way to use the artifact actions to move the images between jobs.
+# Utilizing the cache-{from, to} type `local` makes this surprisingly easy:
 
 name: Docker Caching
 
@@ -118,7 +118,6 @@ jobs:
           push: false
 
   stage2:
-    if: false
     needs: [base-image, dockerfile]
     runs-on: ubuntu-latest
     steps:
@@ -128,15 +127,20 @@ jobs:
         run: |
           echo "$DOCKERFILE_CONTENT" > Dockerfile
 
-      - name: Get Base
+      - name: Get Base Cache
         uses: actions/download-artifact@v4
         with:
           name: base
+          path: /tmp/docker_cache
 
-      - name: Import image
-        run: |
-          docker load -i base.tar
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Build Stage 2
-        run: |
-          docker build --target stage2 .
+      - name: Build Base Image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: stage2
+          tags: stage2:latest
+          cache-from: type=local,src=/tmp/docker_cache
+          push: false

--- a/.github/workflows/docker-caching.yml
+++ b/.github/workflows/docker-caching.yml
@@ -69,4 +69,35 @@ jobs:
           DOCKERFILE_CONTENT: ${{ needs.dockerfile.outputs.dockerfile }}
         run: |
           echo "$DOCKERFILE_CONTENT" > Dockerfile
-          cat Dockerfile
+
+      - name: Build Base Image
+        run: |
+          docker build --load --target base -t base:latest .
+          docker save -o base.tar
+
+      - name: Upload Image
+        uses: actions/upload-artifact@v4
+        with:
+          name: base
+          path: base.tar
+          retention-days: 5
+
+  stage1:
+    needs: base-image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save Dockerfile
+        env:
+          DOCKERFILE_CONTENT: ${{ needs.dockerfile.outputs.dockerfile }}
+        run: |
+          echo "$DOCKERFILE_CONTENT" > Dockerfile
+
+      - name: Get Base
+        uses: actions/download-artifact@v4
+        with:
+          name: base
+
+      - name: Import image
+        run: |
+          docker load -i base.tar
+          docker image ls

--- a/.github/workflows/docker-caching.yml
+++ b/.github/workflows/docker-caching.yml
@@ -100,4 +100,30 @@ jobs:
       - name: Import image
         run: |
           docker load -i base.tar
-          docker image ls
+
+      - name: Build Stage 2
+        run: |
+          docker build --target stage1
+
+  stage2:
+    needs: base-image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save Dockerfile
+        env:
+          DOCKERFILE_CONTENT: ${{ needs.dockerfile.outputs.dockerfile }}
+        run: |
+          echo "$DOCKERFILE_CONTENT" > Dockerfile
+
+      - name: Get Base
+        uses: actions/download-artifact@v4
+        with:
+          name: base
+
+      - name: Import image
+        run: |
+          docker load -i base.tar
+
+      - name: Build Stage 2
+        run: |
+          docker build --target stage2

--- a/.github/workflows/docker-caching.yml
+++ b/.github/workflows/docker-caching.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Build Base Image
         run: |
           docker build --load --target base -t base:latest .
-          docker save -o base.tar
+          docker save -o base.tar base:latest
 
       - name: Upload Image
         uses: actions/upload-artifact@v4

--- a/.github/workflows/docker-caching.yml
+++ b/.github/workflows/docker-caching.yml
@@ -1,0 +1,72 @@
+# Copyright Jacob Wujciak-Jens
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Caching of docker images mostly uses registries, which is not an option
+# for workflows triggered through `pull_request`. Docker recently added
+# an experimental GitHub Actions cache backend but this suffers from the
+# 10GB/repo limitation.
+#
+# Caching is specifically useful when there is a base image that is used
+# by multiple other images that all have a long build time and thus benefit
+# from parallelization.
+#
+# So let's find a way to use the artifact actions to move the images between jobs.
+
+name: Docker Caching
+
+on:
+  push:
+    paths:
+      - .github/workflows/docker-caching.yml
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  dockerfile:
+    runs-on: ubuntu-latest
+    outputs:
+      dockerfile: ${{ steps.dockerfile.outputs.content }}
+    steps:
+      - name: Create Dockerfile
+        id: dockerfile
+        run: |
+          DOCKERFILE=$(cat << 'EOL'
+          # Base image
+          FROM ubuntu:20.04 AS base
+          RUN apt-get update && apt-get upgrade -y
+
+          # Stage 1
+          FROM base AS stage1
+          RUN apt-get install -y curl wget
+
+          # Stage 2
+          FROM base AS stage2
+          RUN apt-get install -y nginx redis-server
+          EOL
+          )
+          echo "content<<EOF" >> $GITHUB_OUTPUT
+          echo "$DOCKERFILE" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+  base-image:
+    needs: dockerfile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save Dockerfile
+        env:
+          DOCKERFILE_CONTENT: ${{ needs.dockerfile.outputs.dockerfile }}
+        run: |
+          echo "$DOCKERFILE_CONTENT" > Dockerfile
+          cat Dockerfile

--- a/.github/workflows/docker-caching.yml
+++ b/.github/workflows/docker-caching.yml
@@ -70,16 +70,23 @@ jobs:
         run: |
           echo "$DOCKERFILE_CONTENT" > Dockerfile
 
-      - name: Build Base Image
-        run: |
-          docker build --load --target base -t base:latest .
-          docker save -o base.tar base:latest
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Upload Image
+      - name: Build Base Image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: base
+          tags: base:latest
+          cache-to: type=local,src=/tmp/docker_cache
+          push: false
+
+      - name: Upload Docker Cache
         uses: actions/upload-artifact@v4
         with:
           name: base
-          path: base.tar
+          path: /tmp/docker_cache
           retention-days: 5
 
   stage1:
@@ -92,20 +99,26 @@ jobs:
         run: |
           echo "$DOCKERFILE_CONTENT" > Dockerfile
 
-      - name: Get Base
+      - name: Get Base Cache
         uses: actions/download-artifact@v4
         with:
           name: base
+          path: /tmp/docker_cache
 
-      - name: Import image
-        run: |
-          docker load -i base.tar
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Build Stage 2
-        run: |
-          docker build --target stage1 .
+      - name: Build Base Image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: stage1
+          tags: stage1:latest
+          cache-from: type:local,src=/tmp/docker_cache
+          push: false
 
   stage2:
+    if: false
     needs: [base-image, dockerfile]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docker-caching.yml
+++ b/.github/workflows/docker-caching.yml
@@ -79,7 +79,7 @@ jobs:
           context: .
           target: base
           tags: base:latest
-          cache-to: type=local,src=/tmp/docker_cache
+          cache-to: type=local,dest=/tmp/docker_cache
           push: false
 
       - name: Upload Docker Cache

--- a/.github/workflows/docker-caching.yml
+++ b/.github/workflows/docker-caching.yml
@@ -83,7 +83,7 @@ jobs:
           retention-days: 5
 
   stage1:
-    needs: base-image
+    needs: [base-image, dockerfile]
     runs-on: ubuntu-latest
     steps:
       - name: Save Dockerfile
@@ -106,7 +106,7 @@ jobs:
           docker build --target stage1 .
 
   stage2:
-    needs: base-image
+    needs: [base-image, dockerfile]
     runs-on: ubuntu-latest
     steps:
       - name: Save Dockerfile

--- a/.github/workflows/docker-caching.yml
+++ b/.github/workflows/docker-caching.yml
@@ -114,7 +114,7 @@ jobs:
           context: .
           target: stage1
           tags: stage1:latest
-          cache-from: type:local,src=/tmp/docker_cache
+          cache-from: type=local,src=/tmp/docker_cache
           push: false
 
   stage2:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "*": any


### PR DESCRIPTION
In arrow we set and cache the volume prefix but looking at this version that seems archaic.

It really is surprisingly easy to use `cache-to type=local,src=/path/` and transfer that via artifacts within the job. 